### PR TITLE
index: kafka: stream: Commit index files in the background

### DIFF
--- a/src/commands/sources/buf_source.rs
+++ b/src/commands/sources/buf_source.rs
@@ -47,8 +47,4 @@ impl Source for BufSource {
         self.line.clear();
         Ok(SourceItem::Document(map))
     }
-
-    async fn on_index_created(&mut self) -> Result<()> {
-        Ok(())
-    }
 }

--- a/src/commands/sources/mod.rs
+++ b/src/commands/sources/mod.rs
@@ -29,9 +29,18 @@ pub trait Source {
     /// Get a document from the source.
     async fn get_one(&mut self) -> Result<SourceItem>;
 
-    /// Called when an index file was just created to notify the source.
-    /// Useful for implementing checkpoints for example.
-    async fn on_index_created(&mut self) -> Result<()>;
+    /// If the source supports checkpointing, it creates a checkpoint commiter that stores a
+    /// snapshot of the last read state. Once the indexer has successfuly commited and uploaded
+    /// the new index file, it tells the checkpoint commiter to commit the snapshot.
+    async fn get_checkpoint_commiter(&mut self) -> Option<Box<dyn CheckpointCommiter + Send>> {
+        None
+    }
+}
+
+#[async_trait]
+pub trait CheckpointCommiter {
+    /// Commit the stored state snapshot.
+    async fn commit(&self) -> Result<()>;
 }
 
 pub async fn connect_to_source(

--- a/tests/kafka_indexing.rs
+++ b/tests/kafka_indexing.rs
@@ -36,7 +36,7 @@ use toshokan::{
         index::{run_index, BatchResult, IndexRunner},
         sources::{
             kafka_source::{parse_url, KafkaSource},
-            Source, SourceItem,
+            CheckpointCommiter, Source, SourceItem,
         },
     },
     config::IndexConfig,
@@ -253,8 +253,13 @@ impl Source for ArcSource {
         self.0.clone().lock_owned().await.get_one().await
     }
 
-    async fn on_index_created(&mut self) -> Result<()> {
-        self.0.clone().lock_owned().await.on_index_created().await
+    async fn get_checkpoint_commiter(&mut self) -> Option<Box<dyn CheckpointCommiter + Send>> {
+        self.0
+            .clone()
+            .lock_owned()
+            .await
+            .get_checkpoint_commiter()
+            .await
     }
 }
 


### PR DESCRIPTION
Achieves better throughput when indexing, as we continue to read from the source, even while committing an index file.